### PR TITLE
Add the "interface" method to get public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ You'll need a [Python](https://www.python.org/downloads/) interpreter and the fo
 You can install them with `pip`: `pip install -r requirements.txt`
 	
 ## Features
-  - Two ways to grab your IP address
+  - Three ways to grab your IP address
   	- HTTP 
 	- DNS lookup (dig)
+	- Interface (get IP address from public interface directly)
   - IPv4 and IPv6 support (A and AAAA records)
   - Logging
   - One configuration file for multiple records

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -5,6 +5,7 @@ from os import path
 from sys import exit
 import logging
 import argparse
+import socket
 from subprocess import Popen, PIPE
 
 # Current directory
@@ -197,6 +198,16 @@ def get_ip(method, record_type):
     elif method == 'http':
         r = requests.get('https://ipv{}.icanhazip.com'.format(v))
         public_ip = r.text.rstrip()
+
+    # Interface resolving method
+    elif method == 'interface':
+        google_public_dns = {
+            4: '8.8.8.8',
+            6: '2001:4860:4860::8888',
+        }
+        with socket.socket(socket.AF_INET if v == 4 else socket.AF_INET6, socket.SOCK_DGRAM) as s:
+            s.connect((google_public_dns[v], 80))
+            public_ip = s.getsockname()[0]
 
     # Save the IP address in cache
     IP_ADDRESSES[v] = public_ip

--- a/zones/example.com.yml
+++ b/zones/example.com.yml
@@ -31,5 +31,5 @@ cf_records:
 
 # This is the method used to discover the server's IP address
 # The faster one is 'dig' but it may not be available on your system
-# Available methods: 'http' or 'dig'
+# Available methods: 'http', 'dig', or 'interface'
 cf_resolving_method: 'http'


### PR DESCRIPTION
Some ISPs do NAT on the way to public IP discovery services like icanhazip.com.

This MR adds a new method to get public IP, which is to get it from IP of primary interface directly.