### PR TITLE
update Authentication method

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -61,8 +61,7 @@ def main():
         # Create API authentication headers
         global API_HEADERS
         API_HEADERS = {
-            'X-Auth-Key': cf_api_key,
-            'X-Auth-Email': cf_email
+            '"Authorization': "Bearer " + cf_api_key
         }
 
         # Get zone informations


### PR DESCRIPTION
Cloudflare no longer accepts the old X-Auth methods and instead accepts just the key as an Authentication Bearer